### PR TITLE
Enabling emojis to display in GitHub Pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,1 @@
+gem 'jemoji'

--- a/_config.yml
+++ b/_config.yml
@@ -1,2 +1,4 @@
 theme: jekyll-theme-architect
 title: ESDC Development Community
+plugins:
+  - jemoji


### PR DESCRIPTION
- Adding `jemoji` extension to jekyll
- Customizing jemoji with `Gemfile`

See for issue https://esdc-devcop.github.io/guides/source-control/working-with-git.html#popular-flows-comparison
What the fix looks like https://s-laugh.github.io/guides/source-control/working-with-git.html#popular-flows-comparison